### PR TITLE
Added employee search and filter endpoint

### DIFF
--- a/models/employees.js
+++ b/models/employees.js
@@ -5,7 +5,7 @@
 
 module.exports = (sequelize, DataTypes) => {
     return sequelize.define('employees', {
-      emp_no: { type: DataTypes.NUMBER, allowNull: false, primaryKey: true },
+      emp_no: { type: DataTypes.STRING, allowNull: false, primaryKey: true },
       birth_date: { type: DataTypes.DATE, allowNull: false },
       first_name: { type: DataTypes.STRING, allowNull: false },
       last_name: { type: DataTypes.STRING, allowNull: false },


### PR DESCRIPTION
### _Completes #7_ 

## How to Use
`localhost:172/api/employees/search` returns the **first 20 employees of DB**

### 4 Query String Variables
**All of these are optional**
- `query`   is search term, either:

  - exact employee ID
  - partial/full first
  - partial/full last name
  - First and Last name combo does not work, it's a bit complex and we shouldn't implement it
- `dept`  is exact Department number to filter by (default is All)
- `start` is search result item to start at (default is 0)
- `end`   is search result item to end at (default is 20)

### Examples

**Request**
`localhost:172/api/employees/search?query=georgi&dept=d003&start=0&end=5`

**Response**
```
[
    {
        "name": "Georgi Barinka",
        "id": 12157,
        "dept": "d003",
        "deptName": "Human Resources"
    },
    {
        "name": "Georgi Gilg",
        "id": 72325,
        "dept": "d003",
        "deptName": "Human Resources"
    },
    {
        "name": "Georgi Worfolk",
        "id": 75783,
        "dept": "d003",
        "deptName": "Human Resources"
    },
    {
        "name": "Georgi Merro",
        "id": 79158,
        "dept": "d003",
        "deptName": "Human Resources"
    },
    {
        "name": "Georgi Woycyznski",
        "id": 104315,
        "dept": "d003",
        "deptName": "Human Resources"
    }
]
```