### PR TITLE
Added endpoint to check manager status with full name

### DIFF
--- a/routes/employees.js
+++ b/routes/employees.js
@@ -3,6 +3,50 @@ const sequelize = require('../services/sequelize');
 const Sequelize = require('sequelize');
 var router = express.Router();
 
+// GET /api/employees/check/:full_name
+
+// Pass full_name to see if Employee is a manager or not
+
+router.get('/check/:full_name', (req, res, next) => {
+    const fullName = req.params.full_name
+
+    var splitName = fullName.split(' ')
+
+    var authPack = {
+        id: 0,
+        manager: false
+    }
+
+    sequelize.Employees.findAll({
+        where: {
+            first_name: splitName[0],
+            last_name: splitName[1]
+        },
+        include: {
+            model: sequelize.DeptManager
+        },
+        attributes: ['emp_no']
+    }).then((emp) => {
+
+        authPack.id = emp[0].emp_no
+
+        if (emp[0].dept_managers.length){
+            authPack.manager = true
+            return res.status(200).json(authPack);
+        }
+
+        else {
+            return res.status(200).json(authPack);
+        }
+
+    }).catch((employeeErr) => {
+
+        return res.status(404).json(employeeErr);
+
+    }) // end Employees findAll
+
+});
+
 // GET /api/employees/search?...
 
 // Query String Paramaters:

--- a/services/sequelize.js
+++ b/services/sequelize.js
@@ -47,6 +47,9 @@ Salaries.belongsTo(Employees, {foreignKey: 'emp_no', targetKey: 'emp_no'});
 Employees.hasMany(DeptEmployee, {foreignKey: 'emp_no', sourceKey: 'emp_no'});
 DeptEmployee.belongsTo(Employees, {foreignKey: 'emp_no', targetKey: 'emp_no'});
 
+Employees.hasMany(DeptManager, {foreignKey: 'emp_no', sourceKey: 'emp_no'});
+DeptManager.belongsTo(Employees, {foreignKey: 'emp_no', targetKey: 'emp_no'});
+
 DeptEmployee.hasOne(Departments, {foreignKey: 'dept_no', sourceKey: 'dept_no'});
 Departments.belongsTo(DeptEmployee, {foreignKey: 'dept_no', targetKey: 'dept_no'});
 


### PR DESCRIPTION
### _Completes #11_ 

## How to Use
Server the purpose of
- Directing any employee to correct dashboard
- Checking if an employee is a manager or not

`localhost:172/api/employees/check/:full_name` returns `id` and `manager` status boolean

## Employee Example
**Request**
`localhost:172/api/employees/check/Tzvetan Zielinski`

**Response**
```
{
    "id": 10007,
    "manager": false
}
```

## Manager Example
**Request**
`localhost:172/api/employees/check/DeForest Hagimont`

**Response**
```
{
    "id": 110511,
    "manager": true
}
```